### PR TITLE
fix: branch conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,8 @@ unset HISTFILE && exit
 ###### Perform a branching conditional
 
 ```bash
-true && { echo success;} || { echo failed; }
+true && echo success
+false || echo failed
 ```
 
 ###### Pipe stdout and stderr to separate commands

--- a/README.md
+++ b/README.md
@@ -632,8 +632,7 @@ unset HISTFILE && exit
 ###### Perform a branching conditional
 
 ```bash
-true && echo success
-false || echo failed
+your_command && { echo success;} || { echo failed; }
 ```
 
 ###### Pipe stdout and stderr to separate commands


### PR DESCRIPTION
the example was wrong, you can see that by trying:

```sh
true && { false; } || { echo failed; }
```
in which case `failed` will still be printed.