### PR TITLE
Add apfree-wifidog for HTTP(s) services

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ Linux Security Expert</b></a> - trainings, howtos, checklists, security tools an
 <p>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://varnish-cache.org/"><b>Varnish HTTP Cache</b></a> - HTTP accelerator designed for content-heavy dynamic web sites.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://nginx.org/"><b>Nginx</b></a> - open source web and reverse proxy server that is similar to Apache, but very light weight.<br>
+&nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/liudf0716/apfree_wifidog"><b>apfree-wifidog</b></a> -  a hight efficient captive portal solution for HTTP(s).<br>
 </p>
 
 ##### :black_small_square: Security/hardening


### PR DESCRIPTION
apfree wifidog is a hight efficient captive portal solution for HTTP(s)
Signed-off-by: Dengfeng Liu <liudengfeng@kunteng.org.cn>