### PR TITLE
sterilize shell history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1163,6 +1163,25 @@ column -c3 -s " " -t | \
 sort -nr | nl |  head -n 20
 ```
 
+###### Sterilize bash history
+
+```bash
+function sterile() {
+    history | awk '$2 != "history" { $1=""; print $0 }' | egrep -vi "\
+curl\b+.*(-E|--cert)\b+.*\b*|\
+curl\b+.*--pass\b+.*\b*|\
+curl\b+.*(-U|--proxy-user).*:.*\b*|\
+curl\b+.*(-u|--user).*:.*\b*
+.*(-H|--header).*(token|auth.*)\b+.*|\
+wget\b+.*--.*password\b+.*\b*|\
+http.?://.+:.+@.*\
+" > $HOME/histbuff; history -r $HOME/histbuff;
+}
+
+export PROMPT_COMMAND="sterile"
+
+```
+
 ###### Quickly backup a file
 
 ```bash


### PR DESCRIPTION
### Please review carefully, I am no one's security specialist.

A shell function to help bash's history "forget" curl and wget commands with inline passwords.

Define this function in a user init file such as .bash_profile and have it executed after every command by adding it to an exported PROMPT_COMMAND variable.