### PR TITLE
Change nc remote shell command to work on wide distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -3235,7 +3235,8 @@ client> tar czvfp - /path/to/dir | nc 10.240.30.3 5000
 ###### Launch remote shell
 
 ```bash
-server> nc -l 5000 -e /bin/bash
+server> rm -f /tmp/f; mkfifo /tmp/f
+server> cat /tmp/f | /bin/bash -i 2>&1 | nc -l 127.0.0.1 5000 > /tmp/f
 client> nc 10.240.30.3 5000
 ```
 

--- a/README.md
+++ b/README.md
@@ -3235,6 +3235,11 @@ client> tar czvfp - /path/to/dir | nc 10.240.30.3 5000
 ###### Launch remote shell
 
 ```bash
+# 1)
+server> nc -l 5000 -e /bin/bash
+client> nc 10.240.30.3 5000
+
+# 2)
 server> rm -f /tmp/f; mkfifo /tmp/f
 server> cat /tmp/f | /bin/bash -i 2>&1 | nc -l 127.0.0.1 5000 > /tmp/f
 client> nc 10.240.30.3 5000


### PR DESCRIPTION
`nc` doesn't have seem to have a `-e` flag. Changed it to the example from `nc`s [man page](https://helpmanual.io/man1/nc/).