### PR TITLE
Adding Charles Proxy 

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,6 +752,7 @@ performance of any of your sites from across the globe.<br>
 <p>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://www.capanalysis.net/ca/"><b>CapAnalysis</b></a> - web visual tool to analyze large amounts of captured network traffic (PCAP analyzer).<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/digitalocean/netbox"><b>netbox</b></a> - IP address management (IPAM) and data center infrastructure management (DCIM) tool.<br>
+&nbsp;&nbsp;:small_orange_diamond: <a href="https://www.charlesproxy.com/"><b>Charles Proxy</b></a> - An HTTP proxy / HTTP monitor / Reverse Proxy that enables a developer to view all of the HTTP and SSL / HTTPS traffic between their machine and the Internet.<br>
 </p>
 
 ##### :black_small_square: Labs


### PR DESCRIPTION
An HTTP proxy / HTTP monitor / Reverse Proxy that enables a developer to view all of the HTTP and SSL / HTTPS traffic between their machine and the Internet.