### PR TITLE
Added Bitwarden to Password Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Only main chapters:
 <p>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://keepassxc.org/"><b>KeePassXC</b></a> - store your passwords safely and auto-type them into your everyday websites and apps.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://www.enpass.io/"><b>Enpass</b></a> - password manager and secure wallet.<br>
+&nbsp;&nbsp;:small_orange_diamond: <a href="https://bitwarden.com/"><b>Bitwarden</b></a> - Open source password management solutions for individuals, teams, and business organizations.<br>
 </p>
 
 ##### :black_small_square: Messengers/IRC Clients


### PR DESCRIPTION
Based on unanimous feedback from [this](https://twitter.com/Sean12697/status/1361717059399344137) Tweet discussing LastPass alternatives.