### PR TITLE
Remove Triple DES from OpenSSL section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2602,7 +2602,7 @@ openssl genrsa -out ${_fd} ${_len} )
 ###### Generate private key with passphrase
 
 ```bash
-# _ciph: des3, aes128, aes256
+# _ciph: aes128, aes256
 # _len: 2048, 4096
 ( _ciph="aes128" ; _fd="private.key" ; _len="2048" ; \
 openssl genrsa -${_ciph} -out ${_fd} ${_len} )
@@ -2618,7 +2618,7 @@ openssl rsa -in ${_fd} -out ${_fd_unp} )
 ###### Encrypt existing private key with a passphrase
 
 ```bash
-# _ciph: des3, aes128, aes256
+# _ciph: aes128, aes256
 ( _ciph="aes128" ; _fd="private.key" ; _fd_pass="private_pass.key" ; \
 openssl rsa -${_ciph} -in ${_fd} -out ${_fd_pass}
 ```


### PR DESCRIPTION
Hi! Triple DES [should be replaced with AES/alternative algorithms wherever possible](https://csrc.nist.gov/News/2017/Update-to-Current-Use-and-Deprecation-of-TDEA). I don't think there's any reason to include 3DES as one of the recommended ciphers for encrypting a private key alongside AES, given that OpenSSL also supports ARIA and Camellia for this argument, both of which would be more suitable than 3DES. This commit alters the OpenSSL one-liner section to only recommend AES for symmetric encryption of private keys.