### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ Only main chapters:
 ##### :black_small_square: Privacy
 
 <p>
-&nbsp;&nbsp;:small_orange_diamond: <a href="https://www.privacytools.io/"><b>privacytools.io</b></a> - provides knowledge and tools to protect your privacy against global mass surveillance.<br>
+&nbsp;&nbsp;:small_orange_diamond: <a href="https://www.privacyguides.org/"><b>privacyguides.org</b></a> - provides knowledge and tools to protect your privacy against global mass surveillance.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Test+Servers"><b>DNS Privacy Test Servers</b></a> - DNS privacy recursive servers list (with a 'no logging' policy).<br>
 </p>
 


### PR DESCRIPTION
Change privacytools.io to privacyguides.org.
The team has been renamed as such which's described along with the
reasons in [their blog](https://privacyguides.org/blog/2021/09/14/welcome-to-privacy-guides/).