### PR TITLE
removed angle brackets from <username>

### DIFF
--- a/README.md
+++ b/README.md
@@ -3028,7 +3028,7 @@ gpg -e -r "<username>" dump.sql
 ```
 
   * `-e|--encrypt` - encrypt data
-  * `-r|--recipient` - encrypt for specific <username>
+  * `-r|--recipient` - encrypt for specific username
 
 ###### Decrypt file
 


### PR DESCRIPTION
minor bugfix - the angle brackets in the description for gpg encrypt were not behaving as intended. Removed as the clearest, most expedient solution.