### PR TITLE
Added ffuf tool in Pentesters Arsenal list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1301,6 +1301,8 @@ CyberTalks</b></a> - talks, interviews, and article about cybersecurity.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/gentilkiwi/mimikatz"><b>mimikatz</b></a> - a little tool to play with Windows security.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/sherlock-project/sherlock"><b>sherlock</b></a> - hunt down social media accounts by username across social networks.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://owasp.org/www-project-threat-dragon/"><b>OWASP Threat Dragon</b></a> - is a tool used to create threat model diagrams and to record possible threats.<br>
+&nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/ffuf/ffuf"><b>ffuf</b></a> - A tool for directory and virtual host discovery (without DNS records), GET and POST parameter fuzzing.<br>
+&nbsp;&nbsp;:small_orange_diamond: <a href="https://www.wireshark.org"><b>Wireshark</b></a> - is the world’s foremost and widely-used network protocol analyzer.<br>
 </p>
 
 ##### :black_small_square: Pentests bookmarks collection

--- a/README.md
+++ b/README.md
@@ -1302,7 +1302,6 @@ CyberTalks</b></a> - talks, interviews, and article about cybersecurity.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/sherlock-project/sherlock"><b>sherlock</b></a> - hunt down social media accounts by username across social networks.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://owasp.org/www-project-threat-dragon/"><b>OWASP Threat Dragon</b></a> - is a tool used to create threat model diagrams and to record possible threats.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/ffuf/ffuf"><b>ffuf</b></a> - A tool for directory and virtual host discovery (without DNS records), GET and POST parameter fuzzing.<br>
-&nbsp;&nbsp;:small_orange_diamond: <a href="https://www.wireshark.org"><b>Wireshark</b></a> - is the world’s foremost and widely-used network protocol analyzer.<br>
 </p>
 
 ##### :black_small_square: Pentests bookmarks collection


### PR DESCRIPTION
# Tool: ffuf (Fuzz Faster U Fool)
Type: Discovery
Description: A fast web fuzzer written in Go. Allows typical directory discovery, virtual host discovery (without DNS records), and GET and POST parameter fuzzing.
Official GitHub: https://github.com/ffuf/ffuf
