### PR TITLE
Added CLI tools: Yakuake, k9s and lazygit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Only main chapters:
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://www.gnu.org/software/screen/"><b>screen</b></a> - is a full-screen window manager that multiplexes a physical terminal.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/tmux/tmux/wiki"><b>tmux</b></a> - is a terminal multiplexer, lets you switch easily between several programs in one terminal.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/peikk0/tmux-cssh"><b>tmux-cssh</b></a> - is a tool to set comfortable and easy to use functionality, clustering and synchronizing tmux-sessions.<br>
+&nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/KDE/yakuake"><b>yakuake</b></a> - is a highly customizeable terminal emulator that makes your terminal always accessable as popup window.<br>
 </p>
 
 ##### :black_small_square: Text editors
@@ -389,6 +390,8 @@ Only main chapters:
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/tj/commander.js"><b>commander.js</b></a> - minimal CLI creator in JavaScript.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/tomnomnom/gron"><b>gron</b></a> - make JSON greppable!<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/itchyny/bed"><b>bed</b></a> - binary editor written in Go.<br>
+&nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/jesseduffield/lazygit"><b>lazygit</b></a> - is the most simple and customizeable GIT GUI for your CLI.<br>
+&nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/derailed/k9s"><b>k9s</b></a> - is a full kubernetes (k8) manager that provides a UI inside your terminal.<br>
 </p>
 
 #### GUI Tools &nbsp;[<sup>[TOC]</sup>](#anger-table-of-contents)


### PR DESCRIPTION
Added different CLI tools i am using daily as developer:

- Yakuake: Is a console emulator that makes you terminal always active and pop up your screen pressing F12. It can open multiple different shells, define base paths, customized in colors/transparency, ... and is always very usefull fot switching to the terminal very fast. It is a KDE tool but can be used everywhere meanwhile.
- k9s: is a full kubernetes manager using just the terminal. It has a powerfgul UI, nice intuitive shortcuts and it makes you managing (monitor/edit/switch/...) your clusters very fast. Ofcasue it needs kubectl/az-cli/... as dependency for appling the usual commands. It simply gives them a nice UI and makes it super simple to use.
- lazygit is a full GIT UI inside the terminal. It can be customized on themes, branch colors, .. and wraps up everything nicely. Your full git management it always accessable on your CLI sessions so you never need to leave the terminal again. (X = menu key and your best friend on starting/trying out)