### PR TITLE
Add Gosh Color scheme Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Only main chapters:
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/oh-my-fish/oh-my-fish"><b>Oh My Fish</b></a> - the Fishshell framework.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/starship/starship"><b>Starship</b></a> - the cross-shell prompt written in Rust.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/romkatv/powerlevel10k"><b>powerlevel10k</b></a> - is a fast reimplementation of Powerlevel9k ZSH theme.<br>
+&nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/romkatv/powerlevel10k"><b>Gogh</b></a> - is a collection of color schemes designed for terminal applications.<br>
 </p>
 
 ##### :black_small_square: Shell plugins

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Only main chapters:
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/oh-my-fish/oh-my-fish"><b>Oh My Fish</b></a> - the Fishshell framework.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/starship/starship"><b>Starship</b></a> - the cross-shell prompt written in Rust.<br>
 &nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/romkatv/powerlevel10k"><b>powerlevel10k</b></a> - is a fast reimplementation of Powerlevel9k ZSH theme.<br>
-&nbsp;&nbsp;:small_orange_diamond: <a href="https://github.com/romkatv/powerlevel10k"><b>Gogh</b></a> - is a collection of color schemes designed for terminal applications.<br>
+&nbsp;&nbsp;:small_orange_diamond: <a href="https://gogh-co.github.io/Gogh/"><b>Gogh</b></a> - is a collection of color schemes designed for terminal applications.<br>
 </p>
 
 ##### :black_small_square: Shell plugins


### PR DESCRIPTION

![image](https://github.com/trimstray/the-book-of-secret-knowledge/assets/97372908/64e27d24-39fc-44e6-ab09-5b399c2abe91)

## Description

![image](https://github.com/trimstray/the-book-of-secret-knowledge/assets/97372908/62f4b6f4-381d-4ded-9e54-aa434b42738f)

Added description for Gogh color scheme collection, which offers a range of visually appealing color schemes designed for various terminal applications. These schemes are well-suited for Ubuntu, Linux Mint, Elementary OS, and other distributions using terminals such as Gnome Terminal, Pantheon Terminal, Tilix, and XFCE4 Terminal. The inspiration for these color schemes stems from the design aesthetics of Elementary OS Luna. Notably, these schemes are also compatible with iTerm on macOS.

## Changes Made

- Added a concise yet informative description of the Gogh color scheme collection.
- Mentioned its compatibility with different terminal applications and operating systems.
- Emphasized the inspiration behind the color schemes.

## Checklist

- [x] Confirmed accurate information.
- [x] Followed the formatting guidelines.
- [x] Verified that the provided URLs are active.

Please review and merge this pull request at your convenience. Your feedback and suggestions are highly appreciated. Thank you for maintaining this valuable repository!
