### PR TITLE
fix: remove atom text editor as it has been sunset

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,6 @@ Only main chapters:
 <p>
 &nbsp;&nbsp; <a href="https://www.sublimetext.com/3"><b>Sublime Text</b></a> - is a lightweight, cross-platform code editor known for its speed, ease of use.<br>
 &nbsp;&nbsp; <a href="https://code.visualstudio.com/"><b>Visual Studio Code</b></a> - an open-source and free source code editor developed by Microsoft.<br>
-&nbsp;&nbsp; <a href="https://atom.io/"><b>Atom</b></a> - a hackable text editor for the 21st Century.<br>
 </p>
 
 #### Web Tools &nbsp;[<sup>[TOC]</sup>](#anger-table-of-contents)


### PR DESCRIPTION
Sadly the Atom Text editor has been sunset, maybe "pulsar" could be added to the List instead.
https://github.com/pulsar-edit/pulsar
It is a fork of atom and, to some extend, a community driven successor.

This PR just removes atom, but I will gladly, open another one for adding pulsar.

Also Thank you all very much for the awesome resource that the-book-of-secret-knowledge is!
I found many interesting Things in this beautiful book/list! 🙇

cheers
^C