### PR TITLE
Removed FOFA dead service from repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,6 @@ performance of any of your sites from across the globe.<br>
 &nbsp;&nbsp; <a href="https://viz.greynoise.io/table"><b>GreyNoise</b></a> - mass scanner such as Shodan and Censys.<br>
 &nbsp;&nbsp; <a href="https://www.zoomeye.org/"><b>ZoomEye</b></a> - search engine for cyberspace that lets the user find specific network components.<br>
 &nbsp;&nbsp; <a href="https://netograph.io/"><b>netograph</b></a> - tools to monitor and understand deep structure of the web.<br>
-&nbsp;&nbsp; <a href="https://fofa.so/"><b>FOFA</b></a> - is a cyberspace search engine.<br>
 &nbsp;&nbsp; <a href="https://www.onyphe.io/"><b>onyphe</b></a> - is a search engine for open-source and cyber threat intelligence data collected.<br>
 &nbsp;&nbsp; <a href="https://intelx.io/"><b>IntelligenceX</b></a> - is a search engine and data archive.<br>
 &nbsp;&nbsp; <a href="https://app.binaryedge.io/"><b>binaryedge</b></a> - it scan the entire internet space and create real-time threat intelligence streams and reports.<br>


### PR DESCRIPTION
After discovering the repo and exploring some links here and there, it appears the FOFA link provided is not live anymore.

We can see that when we go to [FOFA](https://fofa.so/) and see a page to buy the website.

Thanks a lot