### PR TITLE
add x-cmd to other list

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Only main chapters:
 &nbsp;&nbsp; <a href="https://github.com/tj/commander.js"><b>commander.js</b></a> - minimal CLI creator in JavaScript.<br>
 &nbsp;&nbsp; <a href="https://github.com/tomnomnom/gron"><b>gron</b></a> - make JSON greppable!<br>
 &nbsp;&nbsp; <a href="https://github.com/itchyny/bed"><b>bed</b></a> - binary editor written in Go.<br>
+&nbsp;&nbsp; <a href="https://github.com/x-cmd/x-cmd"><b>x-cmd</b></a> - A vast and interesting collection of tools that can then bootstrap lots of other programs / functions in a consistent and structured way.<br>
 </p>
 
 #### GUI Tools &nbsp;[<sup>[TOC]</sup>](#anger-table-of-contents)


### PR DESCRIPTION
Hi. Thank you for this collection of useful terminal programs!
I want to add x-cmd to the list.
I have searched the PRs of this repo and believe that this is not a duplicate.

x-cmd is a toolset implemented using posix shell and awk. It is very small in size and offers many interesting features.

**Tools Provided by x-cmd:**
  - [Wrappers for Common Commands (e.g., cd, ip, ps, tar, apt, brew)](https://x-cmd.com/mod/zuz): These wrapped commands are more intelligent and easier to use compared to the native commands.
  - [Lightweight Package Management Tool](https://x-cmd.com/pkg/): We have implemented a lightweight package management tool using shell and awk. Through it, you can quickly obtain most common software tools, such as jq, 7za, bat, nvim, python, node, go, etc.
  - [CLI for Useful Websites (e.g., github.com, cht.sh)](https://x-cmd.com/mod/cht): We have wrapped their APIs using shell and awk for daily use and to obtain corresponding services in scripts.
  - [AI Tools](https://x-cmd.com/mod/openai): We provide CLIs for ChatGPT, Gemini, Jina.ai, etc., and have wrapped corresponding shortcut commands for different application scenarios, such as `@gemini` for chatting with Gemini AI and `@zh` for using AI to translate specified content or command results.
