### PR TITLE
Add new site to Labs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1471,6 +1471,7 @@ AWS deployment tool.<br>
 &nbsp;&nbsp; <a href="https://attackdefense.com"><b>Attack & Defense</b></a> - is a browser-based cloud labs.<br>
 &nbsp;&nbsp; <a href="https://cryptohack.org/"><b>Cryptohack</b></a> - a fun platform for learning modern cryptography.<br>
 &nbsp;&nbsp; <a href="https://cryptopals.com/"><b>Cryptopals</b></a> - the cryptopals crypto challenges.<br>
+&nbsp;&nbsp; <a href="https://labex.io/skilltrees/cybersecurity"><b>LabEx</b></a> - hands-on labs and challenges for cyber security.<br>
 </p>
 
 ##### :black_small_square: CTF platforms


### PR DESCRIPTION
Add LabEx cybersecurity labs to Labs section.

I work at LabEx, a unique learning platform that has delivered thousands of hands-on labs over the past 7 years. Our Cybersecurity Skill Tree currently offers 34 foundational skills and 80 hands-on labs, making it perfect for beginners to learn cybersecurity step by step. 

This repo is a great resource. Please let me know if any changes are needed.