### PR TITLE
Add keyFinder to TOP Browser extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,6 +1572,7 @@ AWS deployment tool.<br>
 | **`d3coder`** | Encoding/Decoding plugin for various types of encoding. |
 | **`Web Developer`** | Adds a toolbar button with various web developer tools. |
 | **`ThreatPinch Lookup`** | Add threat intelligence hover tool tips. |
+| **`keyFinder`** | Passively scans web pages for exposed API keys, tokens, and secrets using 80+ regex patterns and Shannon entropy analysis. |
 
 ###### TOP Burp extensions
 


### PR DESCRIPTION
## Summary

- Adds [keyFinder](https://github.com/momenbasel/keyFinder) to the **TOP Browser extensions** section
- keyFinder is a Chrome extension (556+ stars, MIT license) that passively scans every web page for leaked API keys, tokens, and secrets using 80+ regex detection patterns and Shannon entropy analysis
- Manifest V3, zero dependencies, covers 10 attack surfaces (AWS, GCP, Azure, Stripe, Slack, GitHub, etc.)

## Why it belongs here

The TOP Browser extensions section already lists security-focused extensions (FoxyProxy, HTTPS Everywhere, uMatrix, ThreatPinch Lookup). keyFinder fills a gap - there is no secret/credential detection browser extension in the list, despite secret scanning tools (shhgit, KeyHacks) appearing in other sections.